### PR TITLE
Refactor JDTLS Configuration to Use Neovim stdpath

### DIFF
--- a/ftplugin/java.lua
+++ b/ftplugin/java.lua
@@ -1,67 +1,67 @@
-local home = os.getenv 'HOME'
-local workspace_path = home .. '/.local/share/nvim/jdtls-workspace/'
-local project_name = vim.fn.fnamemodify(vim.fn.getcwd(), ':p:h:t')
+local jdtls_path = vim.api.nvim_call_function("stdpath", { "data" }) .. "/mason/packages/jdtls"
+local workspace_path = vim.api.nvim_call_function("stdpath", { "data" }) .. "/jdtls-workspace"
+local project_name = vim.fn.fnamemodify(vim.fn.getcwd(), ":p:h:t")
 local workspace_dir = workspace_path .. project_name
 
-local status, jdtls = pcall(require, 'jdtls')
+local status, jdtls = pcall(require, "jdtls")
 if not status then
-  return
+	return
 end
 local extendedClientCapabilities = jdtls.extendedClientCapabilities
 
 local config = {
-  cmd = {
-    'java',
-    '-Declipse.application=org.eclipse.jdt.ls.core.id1',
-    '-Dosgi.bundles.defaultStartLevel=4',
-    '-Declipse.product=org.eclipse.jdt.ls.core.product',
-    '-Dlog.protocol=true',
-    '-Dlog.level=ALL',
-    '-Xmx1g',
-    '--add-modules=ALL-SYSTEM',
-    '--add-opens',
-    'java.base/java.util=ALL-UNNAMED',
-    '--add-opens',
-    'java.base/java.lang=ALL-UNNAMED',
-    '-javaagent:' .. home .. '/.local/share/nvim/mason/packages/jdtls/lombok.jar',
-    '-jar',
-    vim.fn.glob(home .. '/.local/share/nvim/mason/packages/jdtls/plugins/org.eclipse.equinox.launcher_*.jar'),
-    '-configuration',
-    home .. '/.local/share/nvim/mason/packages/jdtls/config_mac',
-    '-data',
-    workspace_dir,
-  },
-  root_dir = require('jdtls.setup').find_root { '.git', 'mvnw', 'gradlew', 'pom.xml', 'build.gradle' },
+	cmd = {
+		"java",
+		"-Declipse.application=org.eclipse.jdt.ls.core.id1",
+		"-Dosgi.bundles.defaultStartLevel=4",
+		"-Declipse.product=org.eclipse.jdt.ls.core.product",
+		"-Dlog.protocol=true",
+		"-Dlog.level=ALL",
+		"-Xmx1g",
+		"--add-modules=ALL-SYSTEM",
+		"--add-opens",
+		"java.base/java.util=ALL-UNNAMED",
+		"--add-opens",
+		"java.base/java.lang=ALL-UNNAMED",
+		"-javaagent:" .. jdtls_path .. "/lombok.jar",
+		"-jar",
+		vim.fn.glob(jdtls_path .. "/plugins/org.eclipse.equinox.launcher_*.jar"),
+		"-configuration",
+		jdtls_path .. "/config_mac",
+		"-data",
+		workspace_dir,
+	},
+	root_dir = require("jdtls.setup").find_root({ ".git", "mvnw", "gradlew", "pom.xml", "build.gradle" }),
 
-  settings = {
-    java = {
-      signatureHelp = { enabled = true },
-      extendedClientCapabilities = extendedClientCapabilities,
-      maven = {
-        downloadSources = true,
-      },
-      referencesCodeLens = {
-        enabled = true,
-      },
-      references = {
-        includeDecompiledSources = true,
-      },
-      inlayHints = {
-        parameterNames = {
-          enabled = 'all', -- literals, all, none
-        },
-      },
-      format = {
-        enabled = false,
-      },
-    },
-  },
+	settings = {
+		java = {
+			signatureHelp = { enabled = true },
+			extendedClientCapabilities = extendedClientCapabilities,
+			maven = {
+				downloadSources = true,
+			},
+			referencesCodeLens = {
+				enabled = true,
+			},
+			references = {
+				includeDecompiledSources = true,
+			},
+			inlayHints = {
+				parameterNames = {
+					enabled = "all", -- literals, all, none
+				},
+			},
+			format = {
+				enabled = false,
+			},
+		},
+	},
 
-  init_options = {
-    bundles = {},
-  },
+	init_options = {
+		bundles = {},
+	},
 }
-require('jdtls').start_or_attach(config)
+require("jdtls").start_or_attach(config)
 
 vim.keymap.set('n', '<leader>co', "<Cmd>lua require'jdtls'.organize_imports()<CR>", { desc = 'Organize Imports' })
 vim.keymap.set('n', '<leader>crv', "<Cmd>lua require('jdtls').extract_variable()<CR>", { desc = 'Extract Variable' })
@@ -69,4 +69,3 @@ vim.keymap.set('v', '<leader>crv', "<Esc><Cmd>lua require('jdtls').extract_varia
 vim.keymap.set('n', '<leader>crc', "<Cmd>lua require('jdtls').extract_constant()<CR>", { desc = 'Extract Constant' })
 vim.keymap.set('v', '<leader>crc', "<Esc><Cmd>lua require('jdtls').extract_constant(true)<CR>", { desc = 'Extract Constant' })
 vim.keymap.set('v', '<leader>crm', "<Esc><Cmd>lua require('jdtls').extract_method(true)<CR>", { desc = 'Extract Method' })
-


### PR DESCRIPTION
- Refactored the JDTLS setup script to use Neovim's stdpath function for constructing paths.
- Replaced usage of environment variables and home directory paths with Neovim's data directory path.
- This change enhances the portability and alignment with Neovim's standard directory structure.
- Retained the original functionality and key mappings for JDTLS actions.